### PR TITLE
Support luarocks/loverocks

### DIFF
--- a/examples/simple/main.lua
+++ b/examples/simple/main.lua
@@ -34,7 +34,7 @@ function love.keypressed(key, touch, isrepeat)
 
   -- Optional method to just print out the progress of the gif
   curgif:onUpdate(function(gif,curframes,totalframes)
-    print(string.format("Progress: %.2f%% (%d/%d)",gif:progress()*10,curframes,totalframes))
+    print(string.format("Progress: %.2f%% (%d/%d)",gif:progress()*100,curframes,totalframes))
   end)
   curgif:onFinish(function(gif,totalframes)
     print(totalframes.." frames written")

--- a/gifcat-scm-1.rockspec
+++ b/gifcat-scm-1.rockspec
@@ -1,0 +1,22 @@
+package = "gifcat"
+version = "scm-1"
+source = {
+   url = "git://github.com/WetDesertRock/GifCat.git"
+}
+description = {
+   summary = "A simple module for saving gifs from LOVE 0.10.x.",
+   detailed = "A simple module for saving gifs from LOVE 0.10.x.",
+   homepage = "https://github.com/WetDesertRock/GifCat",
+   license = "MIT"
+}
+dependencies = {
+   "lua ~> 5.1",
+   "love ~> 0.10"
+}
+build = {
+   type = "builtin",
+   modules = {
+      gifcatlib = { sources = "src/lua_bindings.c" },
+	  gifcat = "gifcat.lua"
+   }
+}


### PR DESCRIPTION
This adds a rockspec file which, if you're using [Loverocks](https://github.com/Alloyed/loverocks), can be used to build and install gifcat like so:

```
loverocks install <url to gifcat-scm-1.rockspec>
```

Or, once it's uploaded to https://luarocks.org:

```
loverocks install gifcat
```

To support this, I had to move the threaded code into a string. Guessing
the filename from the module name isn't reliable enough: It will only
work when the path it's being required from is exactly `./?.lua`.

Also fixed a typo in the example.
