### PR TITLE
Added support for LOVE 0.11.x and higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ function love.draw()
     -- Show a little recording icon in the upper right hand corner. This will
     --   not get shown in the gif because it is displayed after the call to
     --   captureScreenshot()
-    love.graphics.setColor(255,0,0)
+    love.graphics.setColor(1,0,0)
     love.graphics.circle("fill",love.graphics.getWidth()-10,10,10)
   end
 
-  love.graphics.setColor(255,255,255)
+  love.graphics.setColor(1,1,1)
   love.graphics.print("Current FPS: "..tostring(love.timer.getFPS( )), 0, 0)
 end
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gifcat
 
-A simple module for saving gifs from LOVE 0.10.x.
+A simple module for saving gifs from LOVE 0.11.x.
 
 ![1466962294](https://cloud.githubusercontent.com/assets/6189453/16363754/6f27d956-3b89-11e6-9345-71c3d822e1c8.gif)
 
@@ -65,7 +65,7 @@ function love.keypressed(key, isrepeat)
 
   -- Optional method to just print out the progress of the gif
   curgif:onUpdate(function(gif,curframes,totalframes)
-    print(string.format("Progress: %.2f%% (%d/%d)",gif:progress()*10,curframes,totalframes))
+    print(string.format("Progress: %.2f%% (%d/%d)",gif:progress()*100,curframes,totalframes))
   end)
   curgif:onFinish(function(gif,totalframes)
     print(totalframes.." frames written")
@@ -86,11 +86,11 @@ function love.draw()
 
   if curgif then
     -- Save a frame to our gif.
-    curgif:frame(love.graphics.newScreenshot())
+    love.graphics.captureScreenshot(function(screenshot) curgif:frame(screenshot) end)
 
     -- Show a little recording icon in the upper right hand corner. This will
     --   not get shown in the gif because it is displayed after the call to
-    --   newScreenshot()
+    --   captureScreenshot()
     love.graphics.setColor(255,0,0)
     love.graphics.circle("fill",love.graphics.getWidth()-10,10,10)
   end

--- a/examples/scale/main.lua
+++ b/examples/scale/main.lua
@@ -72,10 +72,10 @@ function love.draw()
   if curgif then
     love.graphics.captureScreenshot(function(screenshot) curgif:frame(screenshot) end)
 
-    love.graphics.setColor(255,0,0)
+    love.graphics.setColor(1,0,0)
     love.graphics.circle("fill",love.graphics.getWidth()-10,10,10)
   end
 
-  love.graphics.setColor(255,255,255)
+  love.graphics.setColor(1,1,1)
   love.graphics.print("Current FPS: "..tostring(love.timer.getFPS( )), 0, 0)
 end

--- a/examples/scale/main.lua
+++ b/examples/scale/main.lua
@@ -42,7 +42,7 @@ function love.keypressed(key, touch, isrepeat)
     --   it down to size.
     curgif = gifcat.newGif(os.time()..".gif",400,300)
     curgif:onUpdate(function(gif,curframes,totalframes)
-      print(string.format("Progress: %f (%d/%d)",gif:progress()*10,curframes,totalframes))
+      print(string.format("Progress: %f (%d/%d)",gif:progress()*100,curframes,totalframes))
     end)
     curgif:onFinish(function(gif,totalframes)
       print(totalframes.." frames written")
@@ -70,7 +70,7 @@ function love.draw()
   end
 
   if curgif then
-    curgif:frame(love.graphics.newScreenshot())
+    love.graphics.captureScreenshot(function(screenshot) curgif:frame(screenshot) end)
 
     love.graphics.setColor(255,0,0)
     love.graphics.circle("fill",love.graphics.getWidth()-10,10,10)

--- a/examples/simple/main.lua
+++ b/examples/simple/main.lua
@@ -34,7 +34,7 @@ function love.keypressed(key, touch, isrepeat)
 
   -- Optional method to just print out the progress of the gif
   curgif:onUpdate(function(gif,curframes,totalframes)
-    print(string.format("Progress: %.2f%% (%d/%d)",gif:progress()*10,curframes,totalframes))
+    print(string.format("Progress: %.2f%% (%d/%d)",gif:progress()*100,curframes,totalframes))
   end)
   curgif:onFinish(function(gif,totalframes)
     print(totalframes.." frames written")
@@ -73,11 +73,11 @@ function love.draw()
   -- On to the gif specific stuff
   if curgif then
     -- Save a frame to our gif.
-    curgif:frame(love.graphics.newScreenshot())
+    love.graphics.captureScreenshot(function(screenshot) curgif:frame(screenshot) end)
 
     -- Show a little recording icon in the upper right hand corner. This will
     --   not get shown in the gif because it is displayed after the call to
-    --   newScreenshot()
+    --   captureScreenshot()
     love.graphics.setColor(255,0,0)
     love.graphics.circle("fill",love.graphics.getWidth()-10,10,10)
   end

--- a/gifcat.lua
+++ b/gifcat.lua
@@ -20,7 +20,7 @@
 
 
 -- Where can we find the gif.so file?
-local GIFLIB = "gifcatlib.so"
+local GIFLIB = "./gifcatlib.so"
 
 -- Where is this file?
 local FILE = (...)


### PR DESCRIPTION
In LOVE 11.0 `love.graphics.newScreenshot` was replaced by `love.graphics.captureScreenshot`, so I updated examples and README to match new function calls.
